### PR TITLE
Refine agentic coding line and link Claude model announcements

### DIFF
--- a/about.markdown
+++ b/about.markdown
@@ -4,7 +4,7 @@ title: about
 permalink: /about/
 ---
 
-I'm a researcher at [Anthropic](https://www.anthropic.com/), working on making LLMs better at agentic coding. I've worked on Claude models since [Opus 4](https://www.anthropic.com/news/claude-4), notably [Opus 4.5](https://www.anthropic.com/news/claude-opus-4-5), [4.6](https://www.anthropic.com/news/claude-opus-4-6), [4.7](https://www.anthropic.com/news/claude-opus-4-7), and [Mythos](https://red.anthropic.com/2026/mythos-preview/).
+I'm a researcher at [Anthropic](https://www.anthropic.com/), working on making LLMs better at agentic coding. I've worked on Claude models since [Opus 4](https://www.anthropic.com/news/claude-4), notably [Opus 4.5](https://www.anthropic.com/news/claude-opus-4-5), [4.6](https://www.anthropic.com/news/claude-opus-4-6), [4.7](https://www.anthropic.com/news/claude-opus-4-7), and [Mythos](https://www.anthropic.com/glasswing).
 
 Before this, I worked on reinforcement learning at [Google DeepMind](https://deepmind.google/). I co-led [AlphaProof](https://deepmind.google/discover/blog/ai-solves-imo-problems-at-silver-medal-level/), where we got an LLM to teach itself enough math to get a silver medal at the International Mathematical Olympiad, _almost_ cracking the [IMO grand challenge](https://imo-grand-challenge.github.io/). This work was [published in Nature](https://www.nature.com/articles/s41586-025-09833-y). I also worked on post-training [Gemini](https://gemini.google.com/).
 

--- a/about.markdown
+++ b/about.markdown
@@ -4,7 +4,7 @@ title: about
 permalink: /about/
 ---
 
-I'm a researcher at [Anthropic](https://www.anthropic.com/), working on agentic coding (think [Claude Code](https://www.anthropic.com/product/claude-code)).
+I'm a researcher at [Anthropic](https://www.anthropic.com/), working on making LLMs better at agentic coding. I've worked on Claude models since [Opus 4](https://www.anthropic.com/news/claude-4), notably [Opus 4.5](https://www.anthropic.com/news/claude-opus-4-5), [4.6](https://www.anthropic.com/news/claude-opus-4-6), [4.7](https://www.anthropic.com/news/claude-opus-4-7), and [Mythos](https://red.anthropic.com/2026/mythos-preview/).
 
 Before this, I worked on reinforcement learning at [Google DeepMind](https://deepmind.google/). I co-led [AlphaProof](https://deepmind.google/discover/blog/ai-solves-imo-problems-at-silver-medal-level/), where we got an LLM to teach itself enough math to get a silver medal at the International Mathematical Olympiad, _almost_ cracking the [IMO grand challenge](https://imo-grand-challenge.github.io/). This work was [published in Nature](https://www.nature.com/articles/s41586-025-09833-y). I also worked on post-training [Gemini](https://gemini.google.com/).
 


### PR DESCRIPTION
Rephrases the about page line to "making LLMs better at agentic coding" and adds links to each model worked on since Opus 4 (Opus 4.5, 4.6, 4.7, and Mythos).


---
_Generated by [Claude Code](https://claude.ai/code/session_018Jyx1oEdV6M1WzY9iB5ZTD)_